### PR TITLE
json_BufferAppend replaced with clsStringAppend

### DIFF
--- a/clsStringAppend.cls
+++ b/clsStringAppend.cls
@@ -1,0 +1,56 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsStringAppend"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = True
+Option Explicit
+'---------------------------------------------------------------------------------------
+' Module    : clsStringAppend
+' Author    : Philip Swannell
+' Date      : 26-Jan-2018
+' Purpose   : Class for constructing strings in a loop, avoiding "Shlemiel the painter" performance
+'---------------------------------------------------------------------------------------
+Option Base 1
+Dim m_TheString As String
+Dim m_NumCharsWritten As Long
+Dim m_NumCharsStored As Long
+
+Public Function Report()
+1         On Error GoTo ErrHandler
+2         Report = VBA.Left$(m_TheString, m_NumCharsWritten)
+3         Exit Function
+ErrHandler:
+4         Err.Raise vbObjectError + 1, , "#clsStringAppend.Report (line " & CStr(Erl) + "): " & Err.Description & "!"
+End Function
+
+Private Function Max(x As Long, y As Long)
+1         If x > y Then
+2             Max = x
+3         Else
+4             Max = y
+5         End If
+End Function
+
+Public Sub Append(TheString As String)
+          Dim L As Long
+          Dim NumCharsToAdd As Long
+1         On Error GoTo ErrHandler
+2         L = VBA.Len(TheString)
+          
+3         If L + m_NumCharsWritten > m_NumCharsStored Then
+4             NumCharsToAdd = Max(L, m_NumCharsStored)
+5             m_TheString = m_TheString + VBA.Space$(NumCharsToAdd)
+6             m_NumCharsStored = m_NumCharsStored + NumCharsToAdd
+7         End If
+
+8         Mid$(m_TheString, m_NumCharsWritten + 1, L) = TheString
+9         m_NumCharsWritten = m_NumCharsWritten + L
+
+10        Exit Sub
+ErrHandler:
+11        Err.Raise vbObjectError + 1, , "#clsStringAppend.Append (line " & CStr(Erl) + "): " & Err.Description & "!"
+End Sub

--- a/modTest1.bas
+++ b/modTest1.bas
@@ -1,0 +1,182 @@
+Attribute VB_Name = "modTest1"
+Option Explicit
+
+Private Declare PtrSafe Function QueryPerformanceFrequency Lib "kernel32" (lpFrequency As Currency) As Long
+Private Declare PtrSafe Function QueryPerformanceCounter Lib "kernel32" (lpPerformanceCount As Currency) As Long
+
+#If Mac Then
+#ElseIf VBA7 Then
+
+Private Declare PtrSafe Sub json_CopyMemory Lib "kernel32" Alias "RtlMoveMemory" _
+    (json_MemoryDestination As Any, json_MemorySource As Any, ByVal json_ByteLength As Long)
+
+#Else
+
+Private Declare Sub json_CopyMemory Lib "kernel32" Alias "RtlMoveMemory" _
+    (json_MemoryDestination As Any, json_MemorySource As Any, ByVal json_ByteLength As Long)
+
+#End If
+
+'---------------------------------------------------------------------------------------
+' Procedure : sElapsedTime
+' Author    : Philip Swannell
+' Date      : 16-Jun-2013
+' Purpose   : Returns time in seconds since system start up. High resolution.
+'             See http://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx
+'---------------------------------------------------------------------------------------
+Function sElapsedTime() As Double
+          Dim a As Currency, b As Currency
+1         On Error GoTo ErrHandler
+
+2         QueryPerformanceCounter a
+3         QueryPerformanceFrequency b
+4         sElapsedTime = a / b
+5         Exit Function
+ErrHandler:
+6         Err.Raise vbObjectError + 1, , "#sElapsedTime (line " & CStr(Erl) + "): " & Err.Description & "!"
+End Function
+
+' -----------------------------------------------------------------------------------------------------------------------
+' Procedure  : CompareTwoMethods
+' Author     : Philip Swannell
+' Date       : 26-Jan-2018
+' Purpose    : Test harness to compare execution speed of existing json_BufferAppend versus clsStringAppend
+'              For N from 1000 to 1000000 I get clsAppend approx 5 times faster than json_BufferAppend
+'              In addition, clsAppend does not use Windows API calls and thus should work on Mac. I presume (but
+'              haven't tested) that the code as is exhibits ""Shlemiel the painter" performance on Mac since
+'              method json_BufferAppend just does naive string append on Mac.
+' -----------------------------------------------------------------------------------------------------------------------
+Sub CompareTwoMethods()
+          Dim Result1 As String, Result2 As String
+          Dim AppendThis As String
+          Dim i As Long, N As Long
+          Dim t1 As Double, t2 As Double, t3 As Double
+          Dim json_buffer As String
+          Dim json_BufferPosition As Long
+          Dim json_BufferLength As Long
+          Dim cSA As New clsStringAppend
+          
+1         On Error GoTo ErrHandler
+2         AppendThis = "xyz"
+3         N = 100000
+
+4         t1 = sElapsedTime()
+
+5         For i = 1 To N
+6             json_BufferAppend json_buffer, AppendThis, json_BufferPosition, json_BufferLength
+7         Next i
+8         Result1 = json_BufferToString(json_buffer, json_BufferPosition, json_BufferLength)
+
+9         t2 = sElapsedTime()
+
+10        For i = 1 To N
+11            cSA.Append AppendThis
+12        Next i
+13        Result2 = cSA.Report
+
+14        t3 = sElapsedTime()
+
+15        Debug.Print String(50, "-")
+16        Debug.Print "N = " & Format(N, "###,###") & " Len(AppendThis) = " & Len(AppendThis)
+17        Debug.Print "Results Agree?", Result1 = Result2
+18        Debug.Print "Time json_BufferToString", Format((t2 - t1) * 1000, "0.000") & " milliseconds"
+19        Debug.Print "Time clsStringAppend", Format((t3 - t2) * 1000, "0.000") & " milliseconds"
+20        Debug.Print "Ratio:               ", (t2 - t1) / (t3 - t2)
+
+
+21        Exit Sub
+ErrHandler:
+22        MsgBox "#CompareTwoMethods (line " & CStr(Erl) + "): " & Err.Description & "!", vbCritical
+End Sub
+
+Private Sub json_BufferAppend(ByRef json_buffer As String, _
+                              ByRef json_Append As Variant, _
+                              ByRef json_BufferPosition As Long, _
+                              ByRef json_BufferLength As Long)
+#If Mac Then
+    json_buffer = json_buffer & json_Append
+#Else
+    ' VBA can be slow to append strings due to allocating a new string for each append
+    ' Instead of using the traditional append, allocate a large empty string and then copy string at append position
+    '
+    ' Example:
+    ' Buffer: "abc  "
+    ' Append: "def"
+    ' Buffer Position: 3
+    ' Buffer Length: 5
+    '
+    ' Buffer position + Append length > Buffer length -> Append chunk of blank space to buffer
+    ' Buffer: "abc       "
+    ' Buffer Length: 10
+    '
+    ' Copy memory for "def" into buffer at position 3 (0-based)
+    ' Buffer: "abcdef    "
+    '
+    ' Approach based on cStringBuilder from vbAccelerator
+    ' http://www.vbaccelerator.com/home/VB/Code/Techniques/RunTime_Debug_Tracing/VB6_Tracer_Utility_zip_cStringBuilder_cls.asp
+
+    Dim json_AppendLength As Long
+    Dim json_LengthPlusPosition As Long
+
+    json_AppendLength = VBA.LenB(json_Append)
+    json_LengthPlusPosition = json_AppendLength + json_BufferPosition
+
+    If json_LengthPlusPosition > json_BufferLength Then
+        ' Appending would overflow buffer, add chunks until buffer is long enough
+        Dim json_TemporaryLength As Long
+
+        json_TemporaryLength = json_BufferLength
+        Do While json_TemporaryLength < json_LengthPlusPosition
+            ' Initially, initialize string with 255 characters,
+            ' then add large chunks (8192) after that
+            '
+            ' Size: # Characters x 2 bytes / character
+            If json_TemporaryLength = 0 Then
+                json_TemporaryLength = json_TemporaryLength + 510
+            Else
+                json_TemporaryLength = json_TemporaryLength + 16384
+            End If
+        Loop
+
+        json_buffer = json_buffer & VBA.Space$((json_TemporaryLength - json_BufferLength) \ 2)
+        json_BufferLength = json_TemporaryLength
+    End If
+
+    ' Copy memory from append to buffer at buffer position
+    json_CopyMemory ByVal json_UnsignedAdd(StrPtr(json_buffer), _
+                    json_BufferPosition), _
+                    ByVal StrPtr(json_Append), _
+                    json_AppendLength
+
+    json_BufferPosition = json_BufferPosition + json_AppendLength
+#End If
+End Sub
+
+Private Function json_BufferToString(ByRef json_buffer As String, ByVal json_BufferPosition As Long, ByVal json_BufferLength As Long) As String
+#If Mac Then
+    json_BufferToString = json_buffer
+#Else
+    If json_BufferPosition > 0 Then
+        json_BufferToString = VBA.Left$(json_buffer, json_BufferPosition \ 2)
+    End If
+#End If
+End Function
+
+#If VBA7 Then
+Private Function json_UnsignedAdd(json_Start As LongPtr, json_Increment As Long) As LongPtr
+#Else
+Private Function json_UnsignedAdd(json_Start As Long, json_Increment As Long) As Long
+#End If
+
+    If json_Start And &H80000000 Then
+        json_UnsignedAdd = json_Start + json_Increment
+    ElseIf (json_Start Or &H80000000) < -json_Increment Then
+        json_UnsignedAdd = json_Start + json_Increment
+    Else
+        json_UnsignedAdd = (json_Start + &H80000000) + (json_Increment + &H80000000)
+    End If
+End Function
+
+
+
+

--- a/modTest2.bas
+++ b/modTest2.bas
@@ -1,0 +1,27 @@
+Attribute VB_Name = "modTest2"
+Option Explicit
+
+' -----------------------------------------------------------------------------------------------------------------------
+' Procedure  : TestRoundTrip
+' Author     : Philip Swannell
+' Date       : 26-Jan-2018
+' Purpose    : For a super simple example check that Dictionary > JSON String > Dictionary gets back to where we started...
+' -----------------------------------------------------------------------------------------------------------------------
+Sub TestRoundTrip()
+
+    Dim DCTIn As New Dictionary
+    Dim DCTOut As Dictionary
+    Dim JsonString As String
+    Dim JsonString2 As String
+
+    DCTIn.Add "Number", 100
+    DCTIn.Add "String", "Hello"
+    DCTIn.Add "Array", Array(1, 2, 3, 4, 5)
+    JsonString = ConvertToJson(DCTIn)
+    
+    Set DCTOut = ParseJson(JsonString)
+    JsonString2 = ConvertToJson(DCTOut)
+    
+    Debug.Print JsonString = JsonString2
+
+End Sub


### PR DESCRIPTION
Replaced calls to json_BufferAppend with simple class module clsStringAppend. Code is faster (x5), and is simpler (no Windows API calls), and simpler to call.

I have not tested my changes on Mac, but existing method json_BufferAppend does "naive" string appending on Mac and so will presumably have poor performance. In contrast clsStringAppend ought to have good performance.

Downside of my change is that users of the code have to import a class module (clsStringAppend) as well as the module JsonConverter. They should be OK with this surely? Though it will make the nifty training video a bit out-of-date. :-(

The module modTest1 is a test harness for json_BufferAppend versus clsStringAppend, and modTest2 is a really simple check that the changes I've made work. Neither of those modules need to be in the project.