### PR TITLE
 Added support for unquoted String Values

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -533,6 +533,20 @@ Private Function json_ParseValue(json_String As String, ByRef json_Index As Long
         ElseIf VBA.Mid$(json_String, json_Index, 4) = "null" Then
             json_ParseValue = Null
             json_Index = json_Index + 4
+        '#alex_start -----------------------------------------------------------------------------------
+        ElseIf JsonOptions.AllowUnquotedKeys Then
+            Dim json_Char As String
+            Do While json_Index > 0 And json_Index <= Len(json_String)
+                json_Char = VBA.Mid$(json_String, json_Index, 1)
+                If (json_Char <> " ") And (json_Char <> ",") And (json_Char <> "}") And (json_Char <> "]") Then
+                    json_ParseValue = json_ParseValue & json_Char
+                    json_Index = json_Index + 1
+                Else
+                    If IsNumeric(json_ParseValue) Then json_ParseValue = VBA.Val(json_ParseValue)
+                    Exit Do
+                End If
+            Loop
+        '#alex_end -----------------------------------------------------------------------------------
         ElseIf VBA.InStr("+-0123456789", VBA.Mid$(json_String, json_Index, 1)) Then
             json_ParseValue = json_ParseNumber(json_String, json_Index)
         Else


### PR DESCRIPTION
I've found lately JSONs without quotes on the String values (it seems to be called [relaxed json](http://www.relaxedjson.org/)), so I've updated the code to support those:

In this version, if you set the setting `JsonOptions.AllowUnquotedKeys` to `true` it will also allow unquoted value Strings. Unquoted Strings (in this version) end once we find a space, a coma a "}" or a "]".

Notice this captures the numeric values (since not having the quotes to identify the strings, numbers are a potential String) but if `IsNumeric()` it converts them back to number using `VBA.Val()`.

**Next steps:** Future version should clarify the setting: (a) rename it to clarify it works for both key+values or (b) create a new setting to allow unquote key/values separately.

Thanks!