### PR TITLE
Added support for unquoted String Values 

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -533,10 +533,10 @@ Private Function json_ParseValue(json_String As String, ByRef json_Index As Long
                     json_ParseValue = json_ParseValue & json_Char
                     json_Index = json_Index + 1
                 Else  'once finished:
+                    If IsNumeric(json_ParseValue) Then json_ParseValue = VBA.Val(json_ParseValue)
                     If LCase(json_ParseValue) = "true" Then json_ParseValue = True
                     If LCase(json_ParseValue) = "false" Then json_ParseValue = False
                     If LCase(json_ParseValue) = "null" Then json_ParseValue = Null
-                    If IsNumeric(json_ParseValue) Then json_ParseValue = VBA.Val(json_ParseValue)
                     Exit Do
                 End If
             Loop

--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -524,7 +524,24 @@ Private Function json_ParseValue(json_String As String, ByRef json_Index As Long
     Case """", "'"
         json_ParseValue = json_ParseString(json_String, json_Index)
     Case Else
-        If VBA.Mid$(json_String, json_Index, 4) = "true" Then
+        'Start - Unquoted string (asopenag) -----------------------------------------------------------------------------------
+        If JsonOptions.AllowUnquotedKeys Then
+            Dim json_Char As String
+            Do While json_Index > 0 And json_Index <= Len(json_String)
+                json_Char = VBA.Mid$(json_String, json_Index, 1)
+                If (json_Char <> " ") And (json_Char <> ",") And (json_Char <> "}") And (json_Char <> "]") Then
+                    json_ParseValue = json_ParseValue & json_Char
+                    json_Index = json_Index + 1
+                Else  'once finished:
+                    If LCase(json_ParseValue) = "true" Then json_ParseValue = True
+                    If LCase(json_ParseValue) = "false" Then json_ParseValue = False
+                    If LCase(json_ParseValue) = "null" Then json_ParseValue = Null
+                    If IsNumeric(json_ParseValue) Then json_ParseValue = VBA.Val(json_ParseValue)
+                    Exit Do
+                End If
+            Loop
+        'End - Unquoted string (asopenag) -----------------------------------------------------------------------------------
+        ElseIf VBA.Mid$(json_String, json_Index, 4) = "true" Then
             json_ParseValue = True
             json_Index = json_Index + 4
         ElseIf VBA.Mid$(json_String, json_Index, 5) = "false" Then


### PR DESCRIPTION
In current version, you can enable unquoted keys by using `JsonOptions.AllowUnquotedKeys = True`, but that doesn’t capture unquoted values (except, of course, for reserved values like numbers or `null`). But it may happen that you find unquoted values for strings with just one word (I think that’s called [relaxed json](http://www.relaxedjson.org/)). 

Example: `{firstName: John, lastName: Smith}`

I have update the code to cover those cases. 

**How to enable:**
Just set the setting `JsonOptions.AllowUnquotedKeys` to `True`, it will now also capture those 1-word unquoted String values.

**Implementation notes:**
- I assume unquoted String values end once we find a space, a coma, a "}" or a "]" (longer/complex strings are expected to come quoted).
- For this to work, I assume first that all values are strings (including true/false/null/numbers), then I check, and...
   - If `IsNumeric()` I convert the value back to number using `VBA.Val()`.
  - If  = "null" -> `Null`
  - If = "true" / "false" -> `True` / `False`

**Next steps:**
We should clarify the setting `JsonOptions.AllowUnquotedKeys` : (a) rename it to clarify it works for both key and values or (b) create a new setting to allow unquote key/values separately.

Thanks!