### PR TITLE
fix for parse blowing up on mixed case booleans

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -524,13 +524,13 @@ Private Function json_ParseValue(json_String As String, ByRef json_Index As Long
     Case """", "'"
         json_ParseValue = json_ParseString(json_String, json_Index)
     Case Else
-        If VBA.Mid$(json_String, json_Index, 4) = "true" Then
+        If LCase(VBA.Mid$(json_String, json_Index, 4)) = "true" Then
             json_ParseValue = True
             json_Index = json_Index + 4
-        ElseIf VBA.Mid$(json_String, json_Index, 5) = "false" Then
+        ElseIf LCase(VBA.Mid$(json_String, json_Index, 5)) = "false" Then
             json_ParseValue = False
             json_Index = json_Index + 5
-        ElseIf VBA.Mid$(json_String, json_Index, 4) = "null" Then
+        ElseIf LCase(VBA.Mid$(json_String, json_Index, 4)) = "null" Then
             json_ParseValue = Null
             json_Index = json_Index + 4
         ElseIf VBA.InStr("+-0123456789", VBA.Mid$(json_String, json_Index, 1)) Then


### PR DESCRIPTION
We had a situation where the json we needed to parse was being returned with mixed case booleans. That's not proper json of course, but due to complex integrations etc etc we needed the vba json lib to be be tolerate of mixed case booleans. Submitting PR in case this ever affects someone else and the tweak does not alter base functionality.