### PR TITLE
v2.3.2

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -486,7 +486,13 @@ Public Function ParseJsonPart(ByVal JsonString As String, ParamArray keys()) As 
         json_Index = key_Index
         json_ParseKey JsonString, json_Index
     Next
-    ParseJsonPart = json_ParseValue(JsonString, json_Index)
+    json_SkipSpaces JsonString, json_Index
+    Select Case VBA.Mid$(JsonString, json_Index, 1)
+    Case "{", "["
+        Set ParseJsonPart = json_ParseValue(JsonString, json_Index)
+    Case Else
+        ParseJsonPart = json_ParseValue(JsonString, json_Index)
+    End Select
     Exit Function
 ErrorHandling:
     ParseJsonPart = Null


### PR DESCRIPTION
''
' Convert part of JSON string to Variant (Dictionary/Collection/Boolean/String/Double/Null)
'
' @method ParseJsonPart
' @param {String} json_String
' @paramArray {Variant} keys()
' @return {Variant} (Dictionary or Collection or Boolean or String or Double or Null)
' use ParseJsonPart(json_String "foo", "bar", ..."baz")
' like ParseJson(json_String)("foo")("bar")...("baz") but without parse all json_String
''