### PR TITLE
Add Option Private Module

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -44,6 +44,7 @@ Attribute VB_Name = "JsonConverter"
 ' SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ '
 Option Explicit
+Option Private Module
 
 ' === VBA-UTC Headers
 #If Mac Then


### PR DESCRIPTION
This PR aims at fixing an issue mainly with Excel where the functions defined in JsonConverter.bas appear as Excel functions in the autocompletion suggestions and in the Insert Function Window.
![image](https://user-images.githubusercontent.com/31558169/226142788-800c1e12-5afc-4e56-960b-d50eabf095a7.png)
![image](https://user-images.githubusercontent.com/31558169/226142793-b8c29f29-d375-45c1-b95b-f668eedace86.png)

Important note:
The [Option Private Module](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/option-private-statement) only prevents access from outide the VBA project. Hence, this won't affect normal use of VBA-JSON as explained in the documentation :

> When a module contains Option Private Module, the public parts, for example, [variables](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#variable), [objects](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#object), and [user-defined types](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#user-defined-type) declared at the module level, are still available within the [project](https://learn.microsoft.com/en-us/office/vba/language/glossary/vbe-glossary#project) containing the module, but they are not available to other applications or projects.

The only way this could affect negatively someone would be if they were calling JsonConverter's code from another VBProject. However, considering that JsonConverter is easily portable accross project, it's a much better practice to have a copy of it inside the project instead of having an external reference anyway.