### PR TITLE
Fix line feed character parsing in multiline value

### DIFF
--- a/JsonConverter.bas
+++ b/JsonConverter.bas
@@ -575,7 +575,7 @@ Private Function json_ParseString(json_String As String, ByRef json_Index As Lon
                 json_BufferAppend json_Buffer, vbFormFeed, json_BufferPosition, json_BufferLength
                 json_Index = json_Index + 1
             Case "n"
-                json_BufferAppend json_Buffer, vbCrLf, json_BufferPosition, json_BufferLength
+                json_BufferAppend json_Buffer, vbLf, json_BufferPosition, json_BufferLength
                 json_Index = json_Index + 1
             Case "r"
                 json_BufferAppend json_Buffer, vbCr, json_BufferPosition, json_BufferLength


### PR DESCRIPTION
I know this has been discussed in the following issues:

-  #41
- #67 
- #150

As a simple matter of principle, JSON conversion should be _converting_, not _changing_ the original string. A proper conversion should support a round-trip conversion back to the original value. This can be demonstrated with the following code snippet:

```vba
'---------------------------------------------------------------------------------------
' Procedure : TestJsonNewLineIssue
' Author    : Adam Waller
' Date      : 7/24/2023
' Purpose   : Encountered an issue where vbCrLf strings are not parsed correctly when
'           : converting to JSON and back to string values.
'---------------------------------------------------------------------------------------
'
Public Sub TestJsonNewLineIssue()
    
    Const cstrTest As String = "Line1" & vbCrLf & "Line2" & vbCr & "Line3" & vbLf & "Line4" & vbCrLf
    
    Dim dTest As Dictionary
    Dim strResult As String
    
    Set dTest = New Dictionary
    
    dTest("Multiline") = cstrTest
    Debug.Assert dTest("Multiline") = cstrTest
    
    ' Test round trip conversion
    strResult = ParseJson(ConvertToJson(dTest, 2))("Multiline")
    Debug.Assert (strResult = cstrTest)
    
End Sub
```

Replacing a line feed (`vbLf`) single character, with two characters (`vbCrLf`) may be necessary in some applications, but this should be performed in the calling code, not embedded within the JSON conversion. In my opinion, the JSON conversion should only be performing the conversion. What goes in is what should come out.  😄

On the VBA side, `vbCrLf = (vbCr & vbLf)` so I don't know that we need to do anything more complicated than simply converting `\n` to `vbLf`.
